### PR TITLE
Feature/auth

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
     implementation(libs.firebase.firestore)
+    implementation(libs.firebase.auth)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 android {
     namespace = "com.example.bloombooth"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.example.bloombooth"
@@ -35,6 +35,12 @@ android {
         jvmTarget = "1.8"
     }
 
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+        }
+    }
+
     buildFeatures {
         viewBinding = true
     }
@@ -49,9 +55,18 @@ dependencies {
     implementation(libs.androidx.constraintlayout)
     implementation(libs.firebase.firestore)
     implementation(libs.firebase.auth)
+    implementation(libs.androidx.junit.ktx)
+    implementation(libs.androidx.runner)
+    implementation(libs.androidx.espresso.intents)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
+    androidTestImplementation("androidx.test:runner:1.5.2")
+    testImplementation(platform("org.mockito:mockito-core:4.11.0"))
+    androidTestImplementation(libs.mockito.android)
+    androidTestImplementation(libs.androidx.test.core)
+    androidTestImplementation(libs.fragment.testing)
+    androidTestImplementation(libs.mockito)
 
     implementation(platform("com.google.firebase:firebase-bom:33.6.0"))
     // TODO: Add the dependencies for Firebase products you want to use

--- a/app/src/main/java/com/example/bloombooth/AuthActivity.kt
+++ b/app/src/main/java/com/example/bloombooth/AuthActivity.kt
@@ -28,11 +28,4 @@ class AuthActivity : AppCompatActivity() {
             .addToBackStack(null)
             .commit()
     }
-
-    fun navigateToLoginFragment() {
-        supportFragmentManager.beginTransaction()
-            .replace(binding.root.id, LoginFragment())
-            .addToBackStack(null)
-            .commit()
-    }
 }

--- a/app/src/main/java/com/example/bloombooth/AuthActivity.kt
+++ b/app/src/main/java/com/example/bloombooth/AuthActivity.kt
@@ -1,27 +1,31 @@
 package com.example.bloombooth
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
+import com.example.bloombooth.auth.FirebaseAuthManager
 import com.example.bloombooth.databinding.ActivityAuthBinding
-import com.google.firebase.auth.FirebaseAuth
 
 class AuthActivity : AppCompatActivity() {
 
     val binding: ActivityAuthBinding by lazy { ActivityAuthBinding.inflate(layoutInflater) }
-    private lateinit var auth: FirebaseAuth
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContentView(binding.root)
 
-        auth = FirebaseAuth.getInstance()
+        val auth = FirebaseAuthManager.auth
 
-        if (savedInstanceState == null) {
-            supportFragmentManager.beginTransaction()
-                .replace(binding.root.id, LoginFragment(), LoginFragment::class.java.simpleName)
-                .commit()
+        if (auth.currentUser != null) {
+            navigateToMainActivity()
+        } else {
+            if (savedInstanceState == null) {
+                supportFragmentManager.beginTransaction()
+                    .replace(binding.root.id, LoginFragment(), LoginFragment::class.java.simpleName)
+                    .commit()
+            }
         }
     }
 
@@ -36,8 +40,13 @@ class AuthActivity : AppCompatActivity() {
         val loginFragment = LoginFragment()
         supportFragmentManager.beginTransaction()
             .replace(R.id.fragment_container, loginFragment)
-            .addToBackStack(null)  // 백스택에 추가하여 뒤로 가기 버튼을 처리할 수 있도록 함
+            .addToBackStack(null)
             .commit()
     }
 
+    private fun navigateToMainActivity() {
+        val intent = Intent(this, MainActivity::class.java)
+        startActivity(intent)
+        finish()
+    }
 }

--- a/app/src/main/java/com/example/bloombooth/AuthActivity.kt
+++ b/app/src/main/java/com/example/bloombooth/AuthActivity.kt
@@ -3,8 +3,6 @@ package com.example.bloombooth
 import android.os.Bundle
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
 import com.example.bloombooth.databinding.ActivityAuthBinding
 import com.google.firebase.auth.FirebaseAuth
 
@@ -22,15 +20,24 @@ class AuthActivity : AppCompatActivity() {
 
         if (savedInstanceState == null) {
             supportFragmentManager.beginTransaction()
-                .replace(binding.root.id, LoginFragment())
+                .replace(binding.root.id, LoginFragment(), LoginFragment::class.java.simpleName)
                 .commit()
         }
     }
 
     fun navigateToSignUpFragment() {
         supportFragmentManager.beginTransaction()
-            .replace(binding.root.id, RegisterFragment())
+            .replace(R.id.fragment_container, RegisterFragment(), RegisterFragment::class.java.simpleName)
             .addToBackStack(null)
             .commit()
     }
+
+    fun navigateToLoginFragment() {
+        val loginFragment = LoginFragment()
+        supportFragmentManager.beginTransaction()
+            .replace(R.id.fragment_container, loginFragment)
+            .addToBackStack(null)  // 백스택에 추가하여 뒤로 가기 버튼을 처리할 수 있도록 함
+            .commit()
+    }
+
 }

--- a/app/src/main/java/com/example/bloombooth/AuthActivity.kt
+++ b/app/src/main/java/com/example/bloombooth/AuthActivity.kt
@@ -1,0 +1,38 @@
+package com.example.bloombooth
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.example.bloombooth.databinding.ActivityAuthBinding
+import com.google.firebase.auth.FirebaseAuth
+
+class AuthActivity : AppCompatActivity() {
+    val binding: ActivityAuthBinding by lazy { ActivityAuthBinding.inflate(layoutInflater) }
+    private lateinit var auth: FirebaseAuth
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(binding.root)
+
+        auth = FirebaseAuth.getInstance()
+
+        if (savedInstanceState == null) {
+            supportFragmentManager.beginTransaction()
+                .replace(binding.root.id, LoginFragment())
+                .commit()
+        }
+    }
+
+    fun navigateToSignUpFragment() {
+        supportFragmentManager.beginTransaction()
+            .replace(binding.root.id, RegisterFragment())
+            .addToBackStack(null)
+            .commit()
+    }
+
+    fun navigateToLoginFragment() {
+        supportFragmentManager.beginTransaction()
+            .replace(binding.root.id, LoginFragment())
+            .addToBackStack(null)
+            .commit()
+    }
+}

--- a/app/src/main/java/com/example/bloombooth/FirebaseAuthManager.kt
+++ b/app/src/main/java/com/example/bloombooth/FirebaseAuthManager.kt
@@ -1,0 +1,7 @@
+package com.example.bloombooth.auth
+
+import com.google.firebase.auth.FirebaseAuth
+
+object FirebaseAuthManager {
+    val auth: FirebaseAuth = FirebaseAuth.getInstance()
+}

--- a/app/src/main/java/com/example/bloombooth/LoginFragment.kt
+++ b/app/src/main/java/com/example/bloombooth/LoginFragment.kt
@@ -10,16 +10,16 @@ import android.widget.EditText
 import android.widget.TextView
 import android.widget.Toast
 import androidx.fragment.app.Fragment
+import com.example.bloombooth.auth.FirebaseAuthManager
 import com.example.bloombooth.databinding.FragmentLoginBinding
-import com.google.firebase.auth.FirebaseAuth
 
 class LoginFragment : Fragment() {
 
-    private lateinit var auth: FirebaseAuth
     private lateinit var emailEditText: EditText
     private lateinit var passwordEditText: EditText
     private lateinit var loginButton: Button
     private lateinit var signUpText: TextView
+    private val auth = FirebaseAuthManager.auth
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -27,7 +27,6 @@ class LoginFragment : Fragment() {
     ): View? {
         val binding = FragmentLoginBinding.inflate(inflater, container, false)
 
-        auth = FirebaseAuth.getInstance()
         emailEditText = binding.emailInput
         passwordEditText = binding.passwordInput
         loginButton = binding.loginBtn

--- a/app/src/main/java/com/example/bloombooth/LoginFragment.kt
+++ b/app/src/main/java/com/example/bloombooth/LoginFragment.kt
@@ -16,6 +16,9 @@ import com.google.firebase.auth.FirebaseAuth
 class LoginFragment : Fragment() {
 
     private lateinit var auth: FirebaseAuth
+    private lateinit var emailEditText: EditText
+    private lateinit var passwordEditText: EditText
+    private lateinit var loginButton: Button
     private lateinit var signUpText: TextView
 
     override fun onCreateView(
@@ -25,13 +28,41 @@ class LoginFragment : Fragment() {
         val binding = FragmentLoginBinding.inflate(inflater, container, false)
 
         auth = FirebaseAuth.getInstance()
+        emailEditText = binding.emailInput
+        passwordEditText = binding.passwordInput
+        loginButton = binding.loginBtn
         signUpText = binding.signupText
+
+        loginButton.setOnClickListener {
+            loginUser()
+        }
 
         signUpText.setOnClickListener {
             navigateToSignUpFragment()
         }
 
         return binding.root
+    }
+
+    private fun loginUser() {
+        val email = emailEditText.text.toString()
+        val password = passwordEditText.text.toString()
+
+        if (email.isEmpty() || password.isEmpty()) {
+            Toast.makeText(context, "이메일과 비밀번호를 입력해주세요.", Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        auth.signInWithEmailAndPassword(email, password)
+            .addOnCompleteListener(requireActivity()) { task ->
+                if (task.isSuccessful) {
+                    val user = auth.currentUser
+                    startActivity(Intent(context, MainActivity::class.java))
+                    activity?.finish()
+                } else {
+                    Toast.makeText(context, "로그인 실패: ${task.exception?.message}", Toast.LENGTH_SHORT).show()
+                }
+            }
     }
 
     private fun navigateToSignUpFragment() {

--- a/app/src/main/java/com/example/bloombooth/LoginFragment.kt
+++ b/app/src/main/java/com/example/bloombooth/LoginFragment.kt
@@ -1,0 +1,40 @@
+package com.example.bloombooth
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.EditText
+import android.widget.TextView
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import com.example.bloombooth.databinding.FragmentLoginBinding
+import com.google.firebase.auth.FirebaseAuth
+
+class LoginFragment : Fragment() {
+
+    private lateinit var auth: FirebaseAuth
+    private lateinit var signUpText: TextView
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        val binding = FragmentLoginBinding.inflate(inflater, container, false)
+
+        auth = FirebaseAuth.getInstance()
+        signUpText = binding.signupText
+
+        signUpText.setOnClickListener {
+            navigateToSignUpFragment()
+        }
+
+        return binding.root
+    }
+
+    private fun navigateToSignUpFragment() {
+        (activity as? AuthActivity)?.navigateToSignUpFragment()
+    }
+}

--- a/app/src/main/java/com/example/bloombooth/RegisterFragment.kt
+++ b/app/src/main/java/com/example/bloombooth/RegisterFragment.kt
@@ -1,0 +1,160 @@
+package com.example.bloombooth
+
+import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import android.widget.TextView
+import android.widget.Toast
+import androidx.core.content.ContextCompat
+import com.example.bloombooth.databinding.FragmentRegisterBinding
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.userProfileChangeRequest
+
+class RegisterFragment : Fragment() {
+    private var _binding: FragmentRegisterBinding? = null
+    private val binding get() = _binding!!
+    private lateinit var auth: FirebaseAuth
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentRegisterBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        auth = FirebaseAuth.getInstance()
+
+        val toolbar = binding.toolbar
+        toolbar.title = "회원 가입"
+
+        toolbar.setNavigationOnClickListener {
+            requireActivity().onBackPressed()
+        }
+
+        binding.emailVerificationBtn.setOnClickListener {
+            val email = binding.emailInput.text.toString()
+            if (email.isNotEmpty()) {
+                checkEmailAvailability(email)
+            } else {
+                Toast.makeText(requireContext(), "이메일을 입력해주세요.", Toast.LENGTH_SHORT).show()
+            }
+        }
+
+        binding.emailInput.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+
+            override fun afterTextChanged(s: Editable?) {
+                val email = s.toString()
+                if (email.isNotEmpty()) {
+                    binding.emailVerificationBtn.isEnabled = true
+                    binding.emailVerificationBtn.setBackgroundColor(ContextCompat.getColor(requireContext(), R.color.pink))
+                    binding.emailVerificationBtn.setTextColor(ContextCompat.getColor(requireContext(), R.color.white))
+                    binding.emailVerificationBtn.text = "중복 확인"
+                } else {
+                    binding.emailVerificationBtn.setBackgroundColor(ContextCompat.getColor(requireContext(), R.color.gray))
+                    binding.emailVerificationBtn.setTextColor(ContextCompat.getColor(requireContext(), R.color.white))
+                    binding.emailVerificationBtn.text = "중복 확인"
+                }
+            }
+        })
+
+        binding.pwInput.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+
+            override fun afterTextChanged(s: Editable?) {
+                val password = s.toString()
+                if (isPasswordValid(password)) {
+                    binding.passwordError.visibility = TextView.GONE
+                    binding.signupBtn.isEnabled = true
+                } else {
+                    binding.passwordError.visibility = TextView.VISIBLE
+                    binding.signupBtn.isEnabled = false
+                }
+            }
+        })
+
+        binding.signupBtn.setOnClickListener {
+            val email = binding.emailInput.text.toString()
+            val password = binding.pwInput.text.toString()
+            val nickname = binding.nicknameInput.text.toString()
+
+            if (email.isNotEmpty() && password.isNotEmpty() && nickname.isNotEmpty()) {
+                createUser(email, password, nickname)
+            } else {
+                Toast.makeText(requireContext(),
+                    "이메일, 비밀번호, 닉네임을 모두 입력해주세요.", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    private fun checkEmailAvailability(email: String) {
+        auth.fetchSignInMethodsForEmail(email)
+            .addOnCompleteListener { task ->
+                if (task.isSuccessful) {
+                    val result = task.result
+                    if (result?.signInMethods?.isEmpty() == true) {
+                        binding.emailVerificationBtn.setBackgroundColor(ContextCompat.getColor(requireContext(), R.color.pink))
+                        binding.emailVerificationBtn.text = "검증 성공!"
+                        binding.emailVerificationBtn.isEnabled = false
+                        Toast.makeText(requireContext(), "사용 가능한 이메일입니다.", Toast.LENGTH_SHORT).show()
+                    } else {
+                        Toast.makeText(requireContext(), "이미 사용 중인 이메일입니다.", Toast.LENGTH_SHORT).show()
+                    }
+                } else {
+                    Toast.makeText(requireContext(), "이메일 중복검사에 실패했습니다. 다시 시도해주세요.", Toast.LENGTH_SHORT).show()
+                }
+            }
+    }
+
+    private fun isPasswordValid(password: String): Boolean {
+        val regex = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#\$%^&*])[A-Za-z\\d!@#\$%^&*]{6,12}$"
+        return password.matches(regex.toRegex())
+    }
+
+    private fun createUser(email: String, password: String, nickname: String) {
+        auth.createUserWithEmailAndPassword(email, password)
+            .addOnCompleteListener(requireActivity()) { task ->
+                if (task.isSuccessful) {
+                    val user = auth.currentUser
+                    user?.let {
+                        val profileUpdates = userProfileChangeRequest {
+                            displayName = nickname
+                        }
+                        it.updateProfile(profileUpdates)
+                            .addOnCompleteListener { updateTask ->
+                                if (updateTask.isSuccessful) {
+                                    navigateToLoginFragment()
+                                }
+                            }
+                    }
+                } else {
+                    Toast.makeText(requireContext(),
+                        "회원가입이 실패했습니다. : ${task.exception?.message}", Toast.LENGTH_SHORT).show()
+                }
+            }
+    }
+
+    private fun navigateToLoginFragment() {
+        parentFragmentManager.beginTransaction()
+            .replace(R.id.fragment_container, LoginFragment())
+            .addToBackStack(null)
+            .commit()
+    }
+}

--- a/app/src/main/java/com/example/bloombooth/RegisterFragment.kt
+++ b/app/src/main/java/com/example/bloombooth/RegisterFragment.kt
@@ -9,16 +9,16 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
+import com.example.bloombooth.auth.FirebaseAuthManager
 import com.example.bloombooth.databinding.FragmentRegisterBinding
 import com.google.firebase.Firebase
-import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.firestore
 
 class RegisterFragment : Fragment() {
     private var _binding: FragmentRegisterBinding? = null
     private val binding get() = _binding!!
-    private lateinit var auth: FirebaseAuth
+    private val auth = FirebaseAuthManager.auth
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -35,8 +35,6 @@ class RegisterFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        auth = FirebaseAuth.getInstance()
 
         val toolbar = binding.toolbar
         toolbar.title = "회원 가입"

--- a/app/src/main/res/drawable/baseline_arrow_back_ios_24.xml
+++ b/app/src/main/res/drawable/baseline_arrow_back_ios_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:autoMirrored="true" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M11.67,3.87L9.9,2.1 0,12l9.9,9.9 1.77,-1.77L3.54,12z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/main_button.xml
+++ b/app/src/main/res/drawable/main_button.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/pink"/>
+    <corners android:radius="12dp"/>
+</shape>

--- a/app/src/main/res/layout/activity_auth.xml
+++ b/app/src/main/res/layout/activity_auth.xml
@@ -1,0 +1,4 @@
+<FrameLayout android:id="@+id/fragment_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/app/src/main/res/layout/fragment_login.xml
+++ b/app/src/main/res/layout/fragment_login.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".AuthActivity"
+    android:orientation="vertical">
+    <LinearLayout
+        android:id="@+id/splash"
+        android:layout_marginTop="80dp"
+        android:layout_marginLeft="30dp"
+        android:layout_marginRight="30dp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+        <TextView
+            android:id="@+id/app_name_1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/app_name_1"
+            android:fontFamily="@font/main_font"
+            android:textSize="64sp"
+            android:textColor="@color/black"/>
+        <TextView
+            android:id="@+id/app_name_2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/app_name_2"
+            android:fontFamily="@font/main_font"
+            android:textSize="64sp"
+            android:textColor="@color/black"/>
+        <TextView
+            android:id="@+id/catchphrase"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/catchphrase"
+            android:fontFamily="@font/main_font"
+            android:textSize="40sp"
+            android:paddingTop="30dp"
+            android:textColor="@color/black"/>
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/signup_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:textColor="@color/black"
+        android:gravity="start"
+        android:text="회원 가입"/>
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_login.xml
+++ b/app/src/main/res/layout/fragment_login.xml
@@ -41,12 +41,68 @@
             android:textColor="@color/black"/>
     </LinearLayout>
 
-    <TextView
-        android:id="@+id/signup_text"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:gravity="center"
+        android:id="@+id/login_section"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:textColor="@color/black"
-        android:gravity="start"
-        android:text="회원 가입"/>
+        android:layout_marginLeft="30dp"
+        android:layout_marginRight="30dp"
+        android:orientation="vertical">
+
+        <EditText
+            android:id="@+id/email_input"
+            android:layout_marginTop="70dp"
+            android:layout_width="350dp"
+            android:layout_height="50dp"
+            android:hint="이메일을 입력하세요."
+            android:inputType="textEmailAddress"
+            android:maxLines="1"/>
+
+        <EditText
+            android:layout_marginTop="30dp"
+            android:id="@+id/password_input"
+            android:layout_width="350dp"
+            android:layout_height="50dp"
+            android:hint="비밀번호를 입력하세요."
+            android:inputType="textPassword"
+            android:maxLines="1"/>
+
+        <Button
+            android:id="@+id/login_btn"
+            android:layout_width="350dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="40dp"
+            android:background="@drawable/main_button"
+            android:text="로그인" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_marginTop="20dp"
+        android:id="@+id/options"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="30dp"
+        android:layout_marginRight="30dp"
+        android:layout_gravity="center_vertical">
+
+        <TextView
+            android:id="@+id/signup_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:textColor="@color/black"
+            android:gravity="start"
+            android:text="회원 가입"/>
+
+        <TextView
+            android:id="@+id/findPw_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/black"
+            android:text="비밀번호 찾기"
+            android:layout_weight="1"
+            android:gravity="end" />
+
+    </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_register.xml
+++ b/app/src/main/res/layout/fragment_register.xml
@@ -34,7 +34,7 @@
     </LinearLayout>
 
     <LinearLayout
-        android:layout_marginTop="100dp"
+        android:layout_marginTop="70dp"
         android:paddingLeft="30dp"
         android:paddingRight="30dp"
         android:layout_gravity="center"
@@ -63,7 +63,6 @@
                 android:text="중복 확인" />
 
         </LinearLayout>
-
 
         <EditText
             android:id="@+id/email_input"
@@ -109,6 +108,31 @@
             android:textColor="@android:color/holo_red_light"
             android:visibility="gone" />
 
+        <TextView
+            android:layout_marginTop="15dp"
+            android:textSize="20sp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="비밀번호를 다시 한 번 입력해주세요."/>
+
+        <EditText
+            android:id="@+id/pw_check_input"
+            android:maxLines="1"
+            android:layout_width="match_parent"
+            android:layout_height="40dp"
+            android:inputType="textPassword"
+            android:textSize="13sp"
+            android:hint="입력한 비밀번호를 다시 한 번 입력해주세요!"/>
+
+        <TextView
+            android:id="@+id/password_check_error"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="비밀번호가 다릅니다. 다시 확인하세요."
+            android:textColor="@android:color/holo_red_light"
+            android:visibility="gone" />
+
+
     </LinearLayout>
 
     <LinearLayout
@@ -139,7 +163,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textSize="13sp"
-            android:text="닉네임은 6자 ~ 12자여야 하며, 한글, 영문을 포함할 수 있습니다."
+            android:text="닉네임은 2자 ~ 12자여야 하며, 한글, 영문을 포함할 수 있습니다."
             android:textColor="@color/red"
             android:visibility="gone" />
 
@@ -151,6 +175,7 @@
         android:layout_height="wrap_content">
 
         <Button
+            android:enabled="false"
             android:layout_margin="30dp"
             android:paddingLeft="30dp"
             android:paddingRight="30dp"

--- a/app/src/main/res/layout/fragment_register.xml
+++ b/app/src/main/res/layout/fragment_register.xml
@@ -1,0 +1,166 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    tools:context=".RegisterFragment"
+    android:orientation="vertical"
+    android:layout_gravity="center">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:backgroundTint="@color/background_color"
+        android:gravity="center"
+        app:navigationIcon="@drawable/baseline_arrow_back_ios_24"
+        app:titleTextAppearance="@style/ToolbarTitle"
+        app:titleCentered="true" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center">
+
+        <View
+            android:layout_marginLeft="20dp"
+            android:layout_marginRight="20dp"
+            android:layout_width="0dp"
+            android:layout_height="1dp"
+            android:layout_weight="0.8"
+            android:background="@color/black" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_marginTop="100dp"
+        android:paddingLeft="30dp"
+        android:paddingRight="30dp"
+        android:layout_gravity="center"
+        android:id="@+id/email_section"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <TextView
+                android:textSize="20sp"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:text="이메일을 입력해주세요."
+                android:layout_weight="1" />
+
+            <Button
+                android:id="@+id/email_verification_btn"
+                android:backgroundTint="@color/gray"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="중복 확인" />
+
+        </LinearLayout>
+
+
+        <EditText
+            android:id="@+id/email_input"
+            android:inputType="textEmailAddress"
+            android:layout_width="match_parent"
+            android:layout_height="40dp"
+            android:maxLines="1"
+            android:textSize="13sp"
+            android:hint="로그인에 사용할 이메일을 입력해주세요."
+            android:layout_marginTop="10dp" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_marginTop="40dp"
+        android:paddingLeft="30dp"
+        android:paddingRight="30dp"
+        android:id="@+id/pw_section"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:textSize="20sp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="비밀번호를 입력해주세요."/>
+
+        <EditText
+            android:id="@+id/pw_input"
+            android:maxLines="1"
+            android:layout_width="match_parent"
+            android:layout_height="40dp"
+            android:inputType="textPassword"
+            android:textSize="13sp"
+            android:hint="영문, 숫자, 특수문자 포함 6자 ~ 12자여야 합니다."/>
+
+        <TextView
+            android:id="@+id/password_error"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="비밀번호는 영문, 숫자, 특수기호를 포함하여 6자 ~ 12자여야 합니다."
+            android:textColor="@android:color/holo_red_light"
+            android:visibility="gone" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_marginTop="40dp"
+        android:paddingLeft="30dp"
+        android:paddingRight="30dp"
+        android:id="@+id/nickname_section"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:textSize="20sp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="닉네임을 입력해주세요."/>
+
+        <EditText
+            android:id="@+id/nickname_input"
+            android:layout_width="match_parent"
+            android:layout_height="40dp"
+            android:maxLines="1"
+            android:textSize="13sp"
+            android:hint="한글 및 영문을 사용하며, 6자 ~ 12자여아 합니다."/>
+
+        <TextView
+            android:id="@+id/nickname_error"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="13sp"
+            android:text="닉네임은 6자 ~ 12자여야 하며, 한글, 영문을 포함할 수 있습니다."
+            android:textColor="@color/red"
+            android:visibility="gone" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_marginTop="30dp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <Button
+            android:layout_margin="30dp"
+            android:paddingLeft="30dp"
+            android:paddingRight="30dp"
+            android:layout_gravity="center"
+            android:id="@+id/signup_btn"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@drawable/main_button"
+            android:text="회원 가입"/>
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_register.xml
+++ b/app/src/main/res/layout/fragment_register.xml
@@ -163,7 +163,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textSize="13sp"
-            android:text="닉네임은 2자 ~ 12자여야 하며, 한글, 영문을 포함할 수 있습니다."
+            android:text="닉네임은 한글과 영문을 포함할 수 있으며 2자 ~ 12자여야 합니다."
             android:textColor="@color/red"
             android:visibility="gone" />
 

--- a/app/src/main/res/layout/fragment_register.xml
+++ b/app/src/main/res/layout/fragment_register.xml
@@ -156,7 +156,7 @@
             android:layout_height="40dp"
             android:maxLines="1"
             android:textSize="13sp"
-            android:hint="한글 및 영문을 사용하며, 6자 ~ 12자여아 합니다."/>
+            android:hint="한글 및 영문을 사용하며, 2자 ~ 12자여아 합니다."/>
 
         <TextView
             android:id="@+id/nickname_error"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -4,4 +4,6 @@
     <color name="white">#FFFFFFFF</color>
     <color name="background_color">#F6E8E7</color>
     <color name="pink">#E9ABAF</color>
+    <color name="red">#FF0000</color>
+    <color name="gray">#7D7D7D</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,4 +3,5 @@
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
     <color name="background_color">#F6E8E7</color>
+    <color name="pink">#E9ABAF</color>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="ToolbarTitle" parent="TextAppearance.AppCompat.Widget.ActionBar.Title">
+        <item name="android:textAlignment">center</item>
+        <item name="android:textColor">@android:color/black</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,9 +1,9 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
     <style name="Base.Theme.BloomBooth" parent="Theme.Material3.DayNight.NoActionBar">
-        <!-- Customize your light theme here. -->
-        <!-- <item name="colorPrimary">@color/my_light_primary</item> -->
         <item name="android:background">@color/background_color</item>
+        <item name="colorPrimary">@color/pink</item>
+
     </style>
 
     <style name="Theme.BloomBooth" parent="Base.Theme.BloomBooth" />

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ activity = "1.9.3"
 constraintlayout = "2.1.4"
 googleGmsGoogleServices = "4.4.2"
 firebaseFirestore = "25.1.1"
+firebaseAuth = "23.1.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -22,6 +23,7 @@ material = { group = "com.google.android.material", name = "material", version.r
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 firebase-firestore = { group = "com.google.firebase", name = "firebase-firestore", version.ref = "firebaseFirestore" }
+firebase-auth = { group = "com.google.firebase", name = "firebase-auth", version.ref = "firebaseAuth" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,17 +1,24 @@
 [versions]
-agp = "8.6.0"
+agp = "8.6.1"
 kotlin = "1.9.0"
-coreKtx = "1.13.1"
+coreKtx = "1.15.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
 appcompat = "1.7.0"
 material = "1.12.0"
 activity = "1.9.3"
-constraintlayout = "2.1.4"
+constraintlayout = "2.2.0"
 googleGmsGoogleServices = "4.4.2"
 firebaseFirestore = "25.1.1"
 firebaseAuth = "23.1.0"
+androidx-test-core = "1.6.1"
+fragment-testing = "1.8.5"
+mockito = "5.14.2"
+junitKtx = "1.2.1"
+mockitoAndroid = "4.11.0"
+runner = "1.6.2"
+espressoIntents = "3.6.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -24,9 +31,15 @@ androidx-activity = { group = "androidx.activity", name = "activity", version.re
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 firebase-firestore = { group = "com.google.firebase", name = "firebase-firestore", version.ref = "firebaseFirestore" }
 firebase-auth = { group = "com.google.firebase", name = "firebase-auth", version.ref = "firebaseAuth" }
+androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidx-test-core" }
+fragment-testing = { group = "androidx.fragment", name = "fragment-testing", version.ref = "fragment-testing" }
+mockito = { group = "org.mockito", name = "mockito-core", version.ref = "mockito" }
+androidx-junit-ktx = { group = "androidx.test.ext", name = "junit-ktx", version.ref = "junitKtx" }
+androidx-runner = { group = "androidx.test", name = "runner", version.ref = "runner" }
+androidx-espresso-intents = { group = "androidx.test.espresso", name = "espresso-intents", version.ref = "espressoIntents" }
+mockito-android = { module = "org.mockito:mockito-android", version.ref = "mockitoAndroid" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 google-gms-google-services = { id = "com.google.gms.google-services", version.ref = "googleGmsGoogleServices" }
-


### PR DESCRIPTION
## #️⃣ 관련 이슈

- close #1 
- close #2 
- close #6

## 📝작업 내용

> 회원가입과 로그인 기능을 구현했습니다.

## 스크린샷 (선택)
### ❄️ 로그인 실행화면
- 회원가입하지 않은 이메일로 로그인 시도 시 실패
- 틀린 비밀번호로 로그인 시도 시 실패
- 회원가입한 이메일과 비밀번호로 로그인 시 매인 액티비티로 이동
https://github.com/user-attachments/assets/8ad9459f-2e34-4962-a30f-c5bd1879d888


### ❄️ 회원가입 테스트
1. 뒤로 가기 버튼
2.  이메일 검증
- 존재하는 이매일로 시도 시 실패
- 유효하지 않은 이메일로 시도 시 실패
- 가입되지 않은 유효한 이메일으로 시도 시 성공 + 이메일 검증 버튼 비활성화
- 검증 후 입력 필드 수정 발생 시 검증 버튼 재활성화
3. 비밀번호 검증
- 비밀번호 조건을 만족하지 않았을 경우 경고문구가 하단에 등장
4. 비밀번호 재입력 검증
- 3에서 입력한 내용과 다를 경우에 경고문구가 하단에 등장
5. 닉네임 검증
- 비밀번호 조건을 만족하지 않았을 경우 경고문구가 하단에 등장
6. 회원가입
- 2~5를 모두 통과해야 버튼 활성화
- 클릭 시 로그인 화면으로 이동
https://github.com/user-attachments/assets/ae334df1-4495-42e1-bdb4-2f15672997c5